### PR TITLE
Fixing unicode issues in plos groups

### DIFF
--- a/sudoers/init.sls
+++ b/sudoers/init.sls
@@ -16,6 +16,6 @@ sudo:
     - source: salt://sudoers/files/sudoers
     - context:
         included: False
-        ad_groups: {{ ad_groups }}
+        ad_groups: {{ ad_groups|tojson }}
     - require:
       - pkg: sudo


### PR DESCRIPTION
This should resolve the issue @slimeate saw with plos groups getting the unicode identifier put in front of them:

```
# Group privilege specification
%plosops ALL = (ALL:ALL) NOPASSWD: ALL
%sudo ALL = (ALL:ALL) ALL
%u'plosqa' ALL = (ALL:ALL) NOPASSWD: ALL
%u'plosdev' ALL = (ALL:ALL) NOPASSWD: ALL
```

I'm not sure why `plosops` wasn't also getting the unicode identifier, but it should now all render correctly.